### PR TITLE
_next_switchpoint_time needs to be a function call in set_operation_m…

### DIFF
--- a/climate/evohome_cc.py
+++ b/climate/evohome_cc.py
@@ -373,7 +373,7 @@ class EvoZone(EvoChildDevice, ClimateDevice):
                 )
 # until either the next scheduled setpoint, or just an hour from now
                 if self._params[CONF_USE_SCHEDULES]:
-                    until = self._next_switchpoint_time
+                    until = self._next_switchpoint_time()
                 else:
                     until = datetime.now() + timedelta(hours=1)
 


### PR DESCRIPTION
Hi David - 

There are two references to _next_switchpoint_time which should be function calls.  I notice you fixed one of them :-)  

If you're doing a temporary override and you change both the temperature and the operation mode, it's easy to miss the fact that 'until' was only set correctly in one of them.

Quentin
